### PR TITLE
Update to martix-synapse 0.99.1

### DIFF
--- a/matrix/Dockerfile
+++ b/matrix/Dockerfile
@@ -39,7 +39,7 @@ RUN \
     && pip3 install --upgrade pip==19.0.1 \
     && pip3 install \
         pysaml2==4.6.5 \
-        matrix-synapse==0.99.0 \
+        matrix-synapse==0.99.1 \
     \
     && mkdir -p /opt/riot \
     && curl -J -L -o /tmp/riot.tar.gz \


### PR DESCRIPTION
# Proposed Changes

Updates matrix synapse to 0.99.1

https://github.com/matrix-org/synapse/releases/tag/v0.99.1



<blockquote><img src="https://avatars3.githubusercontent.com/u/8418310?s=400&v=4" width="48" align="right"><div><img src="https://github.githubassets.com/favicon.ico" height="14"> GitHub</div><div><strong><a href="https://github.com/matrix-org/synapse">matrix-org/synapse</a></strong></div><div>Synapse: Matrix reference homeserver. Contribute to matrix-org/synapse development by creating an account on GitHub.</div></blockquote>