### PR TITLE
Updated URL

### DIFF
--- a/matrix/config.json
+++ b/matrix/config.json
@@ -3,7 +3,7 @@
   "version": "dev",
   "slug": "matrix",
   "description": "A secure and decentralized communication platform.",
-  "url": "https://community.home-assistant.io",
+  "url": "https://github.com/hassio-addons/addon-matrix",
   "webui": "http://[HOST]:[PORT:80]",
   "startup": "application",
   "ingress": true,


### PR DESCRIPTION
Just where trying things out and was wondering why I come out at the community page.
could it get a problem that it uses the same ingess port as vscode? 
https://github.com/hassio-addons/addon-vscode/blob/master/vscode/config.json#L9

# Proposed Changes

> (Describe the changes and rationale behind them)

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/

<blockquote><img src="https://avatars1.githubusercontent.com/u/30772201?s=400&v=4" width="48" align="right"><div><img src="https://github.githubassets.com/favicon.ico" height="14"> GitHub</div><div><strong><a href="https://github.com/hassio-addons/addon-vscode">hassio-addons/addon-vscode</a></strong></div><div>Visual Studio Code - Community Hass.io Add-on for Home Assistant - hassio-addons/addon-vscode</div></blockquote>