### PR TITLE
:arrow_up: Upgrades add-on base image to v2.0.2

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,8 +8,8 @@ variables:
 
   ADDON_LEGACY_TAGS: "true"
 
-  ADDON_AARCH64_BASE: "hassioaddons/base-python-aarch64:2.0.1"
-  ADDON_AMD64_BASE: "hassioaddons/base-python-amd64:2.0.1"
-  ADDON_ARMHF_BASE: "hassioaddons/base-python-armhf:2.0.1"
-  ADDON_ARMV7_BASE: "hassioaddons/base-python-armv7:2.0.1"
-  ADDON_I386_BASE: "hassioaddons/base-python-i386:2.0.1"
+  ADDON_AARCH64_BASE: "hassioaddons/base-python-aarch64:2.0.2"
+  ADDON_AMD64_BASE: "hassioaddons/base-python-amd64:2.0.2"
+  ADDON_ARMHF_BASE: "hassioaddons/base-python-armhf:2.0.2"
+  ADDON_ARMV7_BASE: "hassioaddons/base-python-armv7:2.0.2"
+  ADDON_I386_BASE: "hassioaddons/base-python-i386:2.0.2"

--- a/matrix/Dockerfile
+++ b/matrix/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=hassioaddons/base-python:2.0.1
+ARG BUILD_FROM=hassioaddons/base-python:2.0.2
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 

--- a/matrix/build.json
+++ b/matrix/build.json
@@ -1,10 +1,10 @@
 {
     "args": {},
     "build_from": {
-        "aarch64": "hassioaddons/base-python-aarch64:2.0.1",
-        "amd64": "hassioaddons/base-python-amd64:2.0.1",
-        "armhf": "hassioaddons/base-python-armhf:2.0.1",
-        "armv7": "hassioaddons/base-python-armv7:2.0.1",
-        "i386": "hassioaddons/base-python-i386:2.0.1"
+        "aarch64": "hassioaddons/base-python-aarch64:2.0.2",
+        "amd64": "hassioaddons/base-python-amd64:2.0.2",
+        "armhf": "hassioaddons/base-python-armhf:2.0.2",
+        "armv7": "hassioaddons/base-python-armv7:2.0.2",
+        "i386": "hassioaddons/base-python-i386:2.0.2"
     }
 }


### PR DESCRIPTION
# Proposed Changes

Based on Python 3.7.4 and the latest Alpine

## Related Issues

n/a

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/