### PR TITLE
Move default config to correct location

### DIFF
--- a/matrix/rootfs/etc/cont-init.d/synapse.sh
+++ b/matrix/rootfs/etc/cont-init.d/synapse.sh
@@ -6,7 +6,7 @@
 readonly CONF="/config/matrix.yaml"
 declare server_name
 
-mv /opt/riot/config.sample.json config.json
+mv /opt/riot/config.sample.json /opt/riot/config.json
 
 if ! bashio::config.has_value 'server_name'; then
     bashio::log.fatal


### PR DESCRIPTION
# Proposed Changes
The default config file is required to work. Instead of moving it to the root of the file system, it should be moved to the root of the web server, which is hosted from /opt/riot.
Manually tested this by moving the file using portainer, now the default page loads correctly.

## Related Issues
Fixes #27 