### PR TITLE
Remove obsolete webui from configuration

### DIFF
--- a/matrix/config.json
+++ b/matrix/config.json
@@ -4,7 +4,6 @@
   "slug": "matrix",
   "description": "A secure and decentralized communication platform.",
   "url": "https://github.com/hassio-addons/addon-matrix",
-  "webui": "http://[HOST]:[PORT:80]",
   "ingress": true,
   "ingress_port": 1337,
   "panel_icon": "mdi:chat",


### PR DESCRIPTION
# Proposed Changes

Removes the `webui` configuration option. It is not used, as the add-on provides Ingress (which takes over the webui button).
