### PR TITLE
Upgrade add-on base image to 6.0.0

### DIFF
--- a/matrix/Dockerfile
+++ b/matrix/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=hassioaddons/base-python:5.2.1
+ARG BUILD_FROM=ghcr.io/hassio-addons/base-python/amd64:6.0.0
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 
@@ -15,27 +15,27 @@ COPY requirements.txt /tmp/
 # Setup Matrix Synapse
 RUN \
     apk add --no-cache --virtual .build-dependencies \
-        build-base=0.5-r1 \
-        libffi-dev=3.2.1-r6 \
-        libjpeg-turbo-dev=2.0.4-r0	 \
-        libressl-dev=3.0.2-r0 \
+        build-base=0.5-r2 \
+        libffi-dev=3.3-r2 \
+        libjpeg-turbo-dev=2.0.6-r0	 \
+        libressl-dev=3.1.5-r0 \
         libxslt-dev=1.1.34-r0 \
-        linux-headers=4.19.36-r0 \
-        musl-dev=1.1.24-r2 \
-        postgresql-dev=12.2-r0 \
+        linux-headers=5.7.8-r0 \
+        musl-dev=1.2.2-r0 \
+        postgresql-dev=13.1-r2 \
         zlib-dev=1.2.11-r3 \
     \
     && apk add --no-cache \
-        libffi=3.2.1-r6 \
-        libjpeg-turbo=2.0.4-r0 \
-        libpq=12.2-r0 \
-        libressl=3.0.2-r0 \
+        libffi=3.3-r2 \
+        libjpeg-turbo=2.0.6-r0 \
+        libpq=13.1-r2 \
+        libressl=3.1.5-r0 \
         libxslt=1.1.34-r0 \
         lua-resty-http=0.15-r0 \
-        nginx-mod-http-lua=1.16.1-r6 \
-        nginx=1.16.1-r6 \
+        nginx-mod-http-lua=1.18.0-r13 \
+        nginx=1.18.0-r13 \
         su-exec=0.2-r1 \
-        tiff=4.1.0-r0 \
+        tiff=4.1.0-r2 \
         zlib=1.2.11-r3 \
     \
     && pip3 install \

--- a/matrix/build.json
+++ b/matrix/build.json
@@ -1,9 +1,9 @@
 {
   "build_from": {
-    "aarch64": "hassioaddons/base-python-aarch64:5.2.1",
-    "amd64": "hassioaddons/base-python-amd64:5.2.1",
-    "armhf": "hassioaddons/base-python-armhf:5.2.1",
-    "armv7": "hassioaddons/base-python-armv7:5.2.1",
-    "i386": "hassioaddons/base-python-i386:5.2.1"
+    "aarch64": "ghcr.io/hassio-addons/base-python/aarch64:6.0.0",
+    "amd64": "ghcr.io/hassio-addons/base-python/amd64:6.0.0",
+    "armhf": "ghcr.io/hassio-addons/base-python/armhf:6.0.0",
+    "armv7": "ghcr.io/hassio-addons/base-python/armv7:6.0.0",
+    "i386": "ghcr.io/hassio-addons/base-python/i386:6.0.0"
   }
 }


### PR DESCRIPTION
# Proposed Changes

Upgrade add-on base image to 6.0.0, which is based on Alpine 3.13 (and thus all deps are upgraded too).